### PR TITLE
fix: build marketcap sync SQL safely

### DIFF
--- a/dag/cd_bppedd_processing_turso.py
+++ b/dag/cd_bppedd_processing_turso.py
@@ -25,7 +25,8 @@ def sql_quote(value):
         return str(value)
     else:
         # Correctly escape single quotes for SQL
-        return f"'{str(value).replace("'", "''")}'"
+        escaped_value = str(value).replace("'", "''")
+        return f"'{escaped_value}'"
 
 
 @dg.asset(

--- a/dag/cd_metrics_processing_turso.py
+++ b/dag/cd_metrics_processing_turso.py
@@ -24,7 +24,8 @@ def sql_quote(value):
         return f"'{value.strftime('%Y-%m-%d')}'"
     else:
         # Escape single quotes for SQL strings
-        return f"'{str(value).replace("'", "''")}'"
+        escaped_value = str(value).replace("'", "''")
+        return f"'{escaped_value}'"
 
 
 @dg.asset(

--- a/dag/cd_price_processing_turso.py
+++ b/dag/cd_price_processing_turso.py
@@ -15,7 +15,8 @@ def sql_quote(value):
     """ 작은따옴표를 SQL 문자열에 맞게 이스케이프합니다. """
     if value is None:
         return "NULL"
-    return f"'{str(value).replace("'", "''")}'"
+    escaped_value = str(value).replace("'", "''")
+    return f"'{escaped_value}'"
 
 def _cursor_to_list_of_dicts(cursor):
     """Converts a database cursor result to a list of dictionaries."""

--- a/dag/cd_raw_ingestion_turso.py
+++ b/dag/cd_raw_ingestion_turso.py
@@ -60,7 +60,8 @@ def sql_quote(value):
     elif isinstance(value, (datetime.date, datetime.datetime)):
         return f"'{value.strftime('%Y-%m-%d')}'" # Standard date format
     else:
-        return f"'{str(value).replace("'", "''")}'"
+        escaped_value = str(value).replace("'", "''")
+        return f"'{escaped_value}'"
 
 
 @dg.asset(


### PR DESCRIPTION
## Summary
- build the marketcap security sync UPDATE statements with pre-escaped fragments to avoid parser errors when Dagster imports the module

## Testing
- pytest dag_tests -vv

------
https://chatgpt.com/codex/tasks/task_e_68cd3b55ec248331bf84294ac4ab9400